### PR TITLE
Feature/local sys info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1030,7 +1030,7 @@ dependencies = [
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "signal-hook 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "systemstat 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "systemstat 0.1.3 (git+https://github.com/myfreeweb/systemstat.git)",
  "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tui 0.3.0-beta.3 (git+https://github.com/wose/tui-rs.git)",
@@ -1210,7 +1210,7 @@ dependencies = [
 [[package]]
 name = "systemstat"
 version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/myfreeweb/systemstat.git#cb7e24853c566ad755be3ca6e9ba419840650a1e"
 dependencies = [
  "bytesize 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1774,7 +1774,7 @@ dependencies = [
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.15.18 (registry+https://github.com/rust-lang/crates.io-index)" = "90c39a061e2f412a9f869540471ab679e85e50c6b05604daf28bc3060f75c430"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
-"checksum systemstat 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "73ea86765e7360e93672afc2b2eb81df13653a8ca2343f6c525e77a4d1d8bdf3"
+"checksum systemstat 0.1.3 (git+https://github.com/myfreeweb/systemstat.git)" = "<none>"
 "checksum tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "55c1195ef8513f3273d55ff59fe5da6940287a0d7a98331254397f464833675b"
 "checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -21,7 +21,7 @@ satnogs-network-client = { path = "../satnogs-network-client" }
 serde = "1.0.8"
 serde_derive = "1.0.8"
 signal-hook = "0.1"
-systemstat = "0.1.3"
+systemstat = { git = "https://github.com/myfreeweb/systemstat.git" }
 termion = "1.5.1"
 time = "0.1"
 tui = { git = "https://github.com/wose/tui-rs.git" , features = ["termion"]}

--- a/monitor/examples/config.toml
+++ b/monitor/examples/config.toml
@@ -7,6 +7,9 @@ log_level = 1
 [[stations]]
 # Your stations SatNOGS id
 satnogs_id = 175
+# Set this to true if the monitor runs on the same machine as the SetNOGS ground station
+# to get system infos (CPU temperature, Mem usage, ...).
+local = false
 # The local IP address of your station
 # This will be used to get realtime information like system status, CPU temperature, ...
 # NOT USED YET
@@ -16,5 +19,5 @@ satnogs_id = 175
 # rt_port = 8377
 
 [ui]
-# number of orbits plotted on the map
+# Number of orbits plotted on the map.
 ground_track_num = 3

--- a/monitor/src/event.rs
+++ b/monitor/src/event.rs
@@ -10,6 +10,6 @@ pub enum Event {
     NoSatnogsNetworkConnection,
     Resize,
     Shutdown,
-    SystemInfo(u64, SysInfo),
+    SystemInfo(Vec<u64>, SysInfo),
     Tick,
 }

--- a/monitor/src/event.rs
+++ b/monitor/src/event.rs
@@ -1,6 +1,7 @@
 //use termion::event::Event;
 use log::Level;
 use crate::satnogs::Data;
+use crate::sysinfo::SysInfo;
 
 pub enum Event {
     Input(termion::event::Event),
@@ -9,5 +10,6 @@ pub enum Event {
     NoSatnogsNetworkConnection,
     Resize,
     Shutdown,
+    SystemInfo(u64, SysInfo),
     Tick,
 }

--- a/monitor/src/main.rs
+++ b/monitor/src/main.rs
@@ -1,8 +1,10 @@
 use clap::{crate_authors, crate_version, value_t, values_t, App, Arg};
 use failure::Fail;
-use log;
+use log::{error, info};
 use satnogs_network_client::Client;
 use std::process;
+use std::thread;
+use systemstat::{Platform, System};
 
 mod event;
 mod job;
@@ -11,13 +13,16 @@ mod satnogs;
 mod settings;
 mod state;
 mod station;
+mod sysinfo;
 mod theme;
 mod ui;
 mod vessel;
 //mod waterfall;
 
+use self::event::Event;
 use self::settings::{Settings, StationConfig};
 use self::station::Station;
+use self::sysinfo::SysInfo;
 
 type Result<T> = std::result::Result<T, failure::Error>;
 
@@ -52,12 +57,45 @@ fn run() -> Result<()> {
         );
     }
 
+    let local_station = settings.local_station;
     let mut tui = ui::Ui::new(settings, client, state)?;
+
+    if local_station {
+        let tx = tui.sender();
+        thread::spawn(move || {
+            while let Ok(sys_info) = get_sysinfo() {
+                match tx.send(Event::SystemInfo(175, sys_info)) {
+                    Ok(_) => thread::sleep(std::time::Duration::new(4, 0)),
+                    Err(e) => {
+                        error!("Failed to send system info: {}", e);
+                        break;
+                    }
+                }
+            }
+        });
+    }
 
     log::set_boxed_logger(Box::new(logger::Logger::new(tui.sender())))?;
 
     tui.update_ground_tracks();
     tui.run()
+}
+
+fn get_sysinfo() -> Result<SysInfo> {
+    let sys = System::new();
+    let cpu_load = sys.cpu_load();
+    thread::sleep(std::time::Duration::new(1, 0));
+
+    info!("{:?}", sys.cpu_temp());
+
+    Ok(
+        SysInfo {
+            cpu_load: cpu_load.and_then(|load| load.done()).ok(),
+            cpu_temp: sys.cpu_temp().ok(),
+            mem: sys.memory().ok(),
+            uptime: sys.uptime().ok(),
+        }
+    )
 }
 
 fn format_error(err: &failure::Error) -> String {
@@ -84,6 +122,12 @@ fn settings() -> Result<Settings> {
                 .help("Sets custom config file")
                 .value_name("FILE")
                 .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("local_station")
+                .short("l")
+                .long("local")
+                .help("Set if a sation runs on the same machine as the monitor")
         )
         .arg(
             Arg::with_name("orbits")
@@ -144,6 +188,10 @@ fn settings() -> Result<Settings> {
 
     if let Ok(orbits) = value_t!(matches.value_of("orbits"), u8) {
         settings.ui.ground_track_num = std::cmp::max(1, orbits);
+    }
+
+    if matches.is_present("local_station") {
+        settings.local_station = true;
     }
 
     Ok(settings)

--- a/monitor/src/settings.rs
+++ b/monitor/src/settings.rs
@@ -4,8 +4,8 @@ use serde_derive::Deserialize;
 
 #[derive(Debug, Deserialize)]
 pub struct StationConfig {
+    pub local: bool,
     pub satnogs_id: u64,
-//    pub name: String,
     pub rt_ip: Option<String>,
     pub rt_port: Option<u32>,
 }
@@ -13,6 +13,7 @@ pub struct StationConfig {
 impl StationConfig {
     pub fn new(id: u64) -> Self {
         StationConfig {
+            local: false,
             satnogs_id: id,
             rt_ip: None,
             rt_port: None,
@@ -35,7 +36,6 @@ impl UiConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {
-    pub local_station: bool,
     pub log_level: Option<u64>,
     pub ui: UiConfig,
     pub stations: Vec<StationConfig>,
@@ -44,7 +44,6 @@ pub struct Settings {
 impl Settings {
     pub fn new() -> Result<Self, ConfigError> {
         let mut settings = Config::new();
-        settings.set_default("local_station", false)?;
         settings.set_default("log_level", 0)?;
         settings.set_default("ui.ground_track_num", 3)?;
         settings.set_default("stations", Vec::<config::Value>::new())?;
@@ -55,7 +54,7 @@ impl Settings {
                     .config_dir()
                     .join("config.toml")
                     .to_str()
-                    .ok_or(ConfigError::Message("Invalid project dir".to_string()))?
+                    .ok_or(ConfigError::Message("Invalid project dir".to_string()))?,
             );
             settings.merge(file.required(false))?;
         }

--- a/monitor/src/settings.rs
+++ b/monitor/src/settings.rs
@@ -35,6 +35,7 @@ impl UiConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct Settings {
+    pub local_station: bool,
     pub log_level: Option<u64>,
     pub ui: UiConfig,
     pub stations: Vec<StationConfig>,
@@ -43,6 +44,7 @@ pub struct Settings {
 impl Settings {
     pub fn new() -> Result<Self, ConfigError> {
         let mut settings = Config::new();
+        settings.set_default("local_station", false)?;
         settings.set_default("log_level", 0)?;
         settings.set_default("ui.ground_track_num", 3)?;
         settings.set_default("stations", Vec::<config::Value>::new())?;

--- a/monitor/src/station.rs
+++ b/monitor/src/station.rs
@@ -3,10 +3,12 @@ use satnogs_network_client as snc;
 use std::fmt;
 
 use crate::job::Job;
+use crate::sysinfo::SysInfo;
 
 pub struct Station {
     pub info: snc::StationInfo,
     pub jobs: Vec<Job>,
+    pub sys_info: SysInfo,
 }
 
 impl Station {
@@ -14,6 +16,7 @@ impl Station {
         Station {
             info: info,
             jobs: vec![],
+            sys_info: Default::default(),
         }
     }
 
@@ -46,6 +49,10 @@ impl Station {
             lon_deg: self.info.lng,
             alt_m: self.info.altitude,
         }
+    }
+
+    pub fn update_sys_info(&mut self, sys_info: SysInfo) {
+        self.sys_info = sys_info;
     }
 }
 

--- a/monitor/src/sysinfo.rs
+++ b/monitor/src/sysinfo.rs
@@ -1,6 +1,6 @@
 use systemstat::data::{CPULoad, Duration, Memory};
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct SysInfo {
     pub cpu_temp: Option<f32>,
     pub cpu_load: Option<Vec<CPULoad>>,

--- a/monitor/src/sysinfo.rs
+++ b/monitor/src/sysinfo.rs
@@ -1,0 +1,9 @@
+use systemstat::data::{CPULoad, Duration, Memory};
+
+#[derive(Default)]
+pub struct SysInfo {
+    pub cpu_temp: Option<f32>,
+    pub cpu_load: Option<Vec<CPULoad>>,
+    pub mem: Option<Memory>,
+    pub uptime: Option<Duration>,
+}

--- a/monitor/src/ui.rs
+++ b/monitor/src/ui.rs
@@ -314,13 +314,20 @@ impl Ui {
                     sys_info.mem.as_ref().map_or(
                         Text::styled("                  -", Style::default().fg(COL_WHITE)),
                         |mem| {
-                            Text::styled(format!("{:19.1}", (mem.free.as_usize() as f32 / mem.total.as_usize() as f32) * 100.0), Style::default().fg(COL_WHITE))
-                        }
+                            Text::styled(
+                                format!(
+                                    "{:19.1}",
+                                    (mem.free.as_usize() as f32 / mem.total.as_usize() as f32)
+                                        * 100.0
+                                ),
+                                Style::default().fg(COL_WHITE),
+                            )
+                        },
                     ),
                     Text::styled(" %\n", Style::default().fg(Color::LightGreen)),
-//                    Text::styled("FS /tmp      ", Style::default().fg(Color::Cyan)),
-//                    Text::styled("                  -", Style::default().fg(COL_WHITE)),
-//                    Text::styled(" %\n", Style::default().fg(Color::LightGreen)),
+                    //                    Text::styled("FS /tmp      ", Style::default().fg(Color::Cyan)),
+                    //                    Text::styled("                  -", Style::default().fg(COL_WHITE)),
+                    //                    Text::styled(" %\n", Style::default().fg(Color::LightGreen)),
                     Text::raw("\n"),
                 ]);
 
@@ -635,12 +642,14 @@ impl Ui {
                 warn!("No connection to SatNOGS network");
             }
             Event::Shutdown => self.shutdown = true,
-            Event::SystemInfo(station_id, sys_info) => {
-                trace!("Got system info for station {}", station_id);
-                self.state
-                    .stations
-                    .entry(station_id)
-                    .and_modify(|station| station.update_sys_info(sys_info));
+            Event::SystemInfo(local_stations, sys_info) => {
+                trace!("Got system info for stations {:?}", local_stations);
+                for id in local_stations {
+                    self.state
+                        .stations
+                        .entry(id)
+                        .and_modify(|station| station.update_sys_info(sys_info.clone()));
+                }
             }
             Event::Tick => {
                 self.handle_tick();

--- a/monitor/src/ui.rs
+++ b/monitor/src/ui.rs
@@ -288,12 +288,22 @@ impl Ui {
                 ];
 
                 if let Some(cpu_load) = &sys_info.cpu_load {
-                    for load in cpu_load {
-                        station_info.push(Text::styled(
-                            format!("{:4.1} ", 100.0 - load.idle * 100.0),
-                            Style::default().fg(COL_WHITE),
-                        ));
-                    }
+                    let load = 100.0
+                        - cpu_load
+                            .iter()
+                            .fold(0.0, |acc, load| acc + load.idle * 100.0)
+                            / cpu_load.len() as f32;
+                    station_info.push(Text::styled(
+                        format!("{:>19.1} ", load),
+                        Style::default().fg(COL_WHITE),
+                    ));
+
+                //                    for load in cpu_load {
+                //                        station_info.push(Text::styled(
+                //                            format!("{:4.1} ", 100.0 - load.idle * 100.0),
+                //                            Style::default().fg(COL_WHITE),
+                //                        ));
+                //                    }
                 } else {
                     station_info.push(Text::styled(
                         "                  - ",
@@ -310,15 +320,17 @@ impl Ui {
                         },
                     ),
                     Text::styled(" °C\n", Style::default().fg(Color::LightGreen)),
-                    Text::styled("MEM          ", Style::default().fg(Color::Cyan)),
+                    Text::styled("Mem          ", Style::default().fg(Color::Cyan)),
                     sys_info.mem.as_ref().map_or(
                         Text::styled("                  -", Style::default().fg(COL_WHITE)),
                         |mem| {
                             Text::styled(
                                 format!(
                                     "{:19.1}",
-                                    (mem.free.as_usize() as f32 / mem.total.as_usize() as f32)
-                                        * 100.0
+                                    100.0
+                                        - (mem.free.as_usize() as f32
+                                            / mem.total.as_usize() as f32)
+                                            * 100.0
                                 ),
                                 Style::default().fg(COL_WHITE),
                             )


### PR DESCRIPTION
The monitor can now collect and display some basic system info (CPU temperature, memory usage, ...) if it runs on the same device as your SatNOGS ground station. The local stations can be specified in the config file (`local = true`) or as command line parameter `-l ID`.

![local_sys_info](https://user-images.githubusercontent.com/76987/49118076-55ed3480-f2a3-11e8-8b4d-3d750fa761a5.png)
