### PR TITLE
Support rotor performing a reset where no position is returned

### DIFF
--- a/monitor/src/rotctld_client.rs
+++ b/monitor/src/rotctld_client.rs
@@ -27,7 +27,13 @@ impl RotCtldClient {
         let mut azimuth = String::new();
         let mut elevation = String::new();
         self.reader.read_line(&mut azimuth)?;
-        self.reader.read_line(&mut elevation)?;
+        if azimuth.starts_with("RPRT") {
+            azimuth.clear();
+            azimuth.push_str("-1");
+            elevation.push_str("-1");
+        } else {
+            self.reader.read_line(&mut elevation)?;
+        }
         let azimuth = azimuth.trim().parse()?;
         let elevation = elevation.trim().parse()?;
 


### PR DESCRIPTION
I noticed that the rotor position would stop to refresh as soon as a reset (to zero the positions for elevation and azimuth) was performed.

This is because during the reset no position is returned for a `p` query. Instead a `RPRT` error is returned, in a single line result instead of two lines for elevation and azimuth. Included is a simple workaround for this problem by returning `-1` degrees for both elevation and azimuth during the reset.

I am sure there are better ways to signal this problem all the way up to the UI, but I do not have the in-depth knowledge of the code to do this.