### PR TITLE
Link libgpredict statically

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "monitor/libgpredict"]
+	path = monitor/libgpredict
+	url = https://github.com/cubehub/libgpredict.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,15 +4,6 @@ FROM rust:latest
 RUN apt update
 RUN DEBIAN_FRONTEND=noninteractive apt install -y vim mc git cmake build-essential libglib2.0-dev
 
-RUN     git clone https://github.com/cubehub/libgpredict.git
-WORKDIR /libgpredict
-RUN     mkdir build
-WORKDIR /libgpredict/build
-RUN     cmake -DBUILD_SHARED_LIBS=ON ../
-RUN     make
-RUN     make install
-RUN     ldconfig
-
 RUN     rustup install stable
 
 COPY    . /satnogs-monitor/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ RUN     ldconfig
 
 RUN     rustup install stable
 
-WORKDIR /
-RUN     git clone --recursive https://github.com/wose/satnogs-monitor.git
+COPY    . /satnogs-monitor/
 WORKDIR /satnogs-monitor/monitor
 RUN     cargo build --release
 

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -28,3 +28,7 @@ hifitime = "3.2.0"
 tui = { git = "https://github.com/wose/tui-rs.git" , features = ["termion"]}
 unicode-width = "0.1.9"
 itertools-num = "0.1.3"
+
+[build-dependencies]
+pkg-config = "0.3"
+cmake = "0.1"

--- a/monitor/build.rs
+++ b/monitor/build.rs
@@ -1,0 +1,28 @@
+fn main() {
+    // Use cmake to build libgpredict
+    let dst = cmake::Config::new("libgpredict")
+        .define("BUILD_SHARED_LIBS", "OFF") // Make sure we build static
+        .define("CMAKE_POSITION_INDEPENDENT_CODE", "ON")
+        .build();
+
+    // Path to the built static library
+    let lib_dir = dst.join("lib");
+
+    println!("cargo:rustc-link-search=native={}", lib_dir.display());
+    println!("cargo:rustc-link-lib=static=gpredict");
+
+    // Ensure glib-2.0 is linked
+    pkg_config::Config::new()
+        .cargo_metadata(true)
+        .probe("glib-2.0")
+        .expect("Failed to find glib-2.0 via pkg-config");
+
+    // Rebuild if anything in gpredict changes
+    println!("cargo:rerun-if-changed=libgpredict");
+
+    // Tell Cargo to find and link against glib
+    pkg_config::Config::new()
+        .atleast_version("2.0")
+        .probe("glib-2.0")
+        .expect("Failed to find glib-2.0 via pkg-config");
+}


### PR DESCRIPTION
This PR omits the necessity to build and install libgpredict on the host system, by building it via cargo and linking it statically into the resulting binary. This should simplify the build process further.

There was a change for this done upstream at:
https://github.com/cubehub/libgpredict/pull/1

This PR depends on https://github.com/wose/satnogs-monitor/pull/56 to be merged first, to fix the rust-serialize error.