### PR TITLE
feature: Clear screen on exit

### DIFF
--- a/monitor/src/ui.rs
+++ b/monitor/src/ui.rs
@@ -417,6 +417,7 @@ impl Ui {
             self.draw()?;
 
             if self.shutdown {
+                self.terminal.clear()?;
                 break;
             }
         }


### PR DESCRIPTION
This is a convenience-fix, which clears the screen on exit of the program. After exit, one will see a normal shell now, instead of a cursor stopping somewhere at the screen.