### PR TITLE
fix: correct sign for next job in less than 1 min

### DIFF
--- a/monitor/src/ui.rs
+++ b/monitor/src/ui.rs
@@ -785,7 +785,11 @@ fn render_next_job_view<T: Backend>(t: &mut Frame<T>, rect: Rect, station: &Stat
             Text::styled(
                 format!(
                     "                {:+4}'{:2}\"\n\n",
-                    delta_t.num_minutes(),
+                    if delta_t.num_minutes() == 0 && delta_t < chrono::Duration::zero() {
+                        -0.0
+                    } else {
+                        delta_t.num_minutes() as f64
+                    },
                     (delta_t.num_seconds() % 60).abs()
                 ),
                 time_style,


### PR DESCRIPTION
Display the correct sign before the minutes if remaining time until next observation is less than 1 minute.

Issue:
<img width="270" height="96" alt="image" src="https://github.com/user-attachments/assets/bf46bbe9-2bea-46a9-bef6-c8ea08bb6108" />

Expected:
<img width="241" height="74" alt="image" src="https://github.com/user-attachments/assets/4bae5e21-48bb-483f-a295-8266d4141b2b" />
