### PR TITLE
feat: fetch actual satellite names from satnogs db

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +374,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -519,6 +531,17 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -748,7 +771,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -931,6 +954,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6180140927ee907000b0aa540091f6ea512ead4447c92b8fc35bc72788a5a6"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "memchr"
@@ -1277,6 +1309,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "satnogs-db-client"
+version = "0.0.0"
+dependencies = [
+ "chrono",
+ "restson",
+ "serde 1.0.228",
+]
+
+[[package]]
 name = "satnogs-monitor"
 version = "0.4.3"
 dependencies = [
@@ -1294,9 +1335,11 @@ dependencies = [
  "itertools-num",
  "lazy_static",
  "log",
+ "lru",
  "notify",
  "pkg-config",
  "regex",
+ "satnogs-db-client",
  "satnogs-network-client",
  "serde 1.0.228",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@
 members = [
     "monitor",
     "satnogs-network-client",
+    "satnogs-db-client",
 ]

--- a/monitor/Cargo.toml
+++ b/monitor/Cargo.toml
@@ -21,6 +21,7 @@ log = { version = "0.4.17", features = ["std"] }
 notify = "5.0.0-pre.2"
 regex = "1.3.9"
 satnogs-network-client = { path = "../satnogs-network-client" }
+satnogs-db-client = { path = "../satnogs-db-client" }
 serde = "1.0.138"
 serde_derive = "1.0.138"
 signal-hook = "0.3.14"
@@ -30,6 +31,7 @@ hifitime = "3.2.0"
 tui = { git = "https://github.com/wose/tui-rs.git" , features = ["termion"]}
 unicode-width = "0.1.9"
 itertools-num = "0.1.3"
+lru = "0.18.1"
 
 [build-dependencies]
 pkg-config = "0.3"

--- a/monitor/src/satnogs.rs
+++ b/monitor/src/satnogs.rs
@@ -1,16 +1,19 @@
 use crate::event::Event;
 use chrono::Utc;
 use log::{debug, error, trace, warn};
+use satnogs_db_client::Satellite;
 use satnogs_network_client::{Job, Observation, ObservationFilter};
 use std::sync::mpsc::{sync_channel, SendError, SyncSender};
 use std::thread;
 
 pub enum Data {
     Jobs(u64, Vec<(Job, Observation)>),
+    Satellite(Satellite),
 }
 
 pub enum Command {
     GetJobs(u64),
+    GetSatellite(String),
 }
 
 pub struct Connection {
@@ -18,10 +21,11 @@ pub struct Connection {
 }
 
 impl Connection {
-    pub fn new(data_tx: SyncSender<Event>, api_endpoint: String) -> Self {
+    pub fn new(data_tx: SyncSender<Event>, api_endpoint: String, db_api_endpoint: String) -> Self {
         let (command_tx, command_rx) = sync_channel(100);
         thread::spawn(move || {
             let mut client = satnogs_network_client::Client::new(&api_endpoint).unwrap();
+            let mut db_client = satnogs_db_client::Client::new(&db_api_endpoint).unwrap();
 
             while let Ok(command) = command_rx.recv() {
                 match command {
@@ -65,6 +69,19 @@ impl Connection {
                         } else {
                             error!("Failed to get observations for station {}", id);
                         }
+                    }
+                    Command::GetSatellite(id) => {
+                        db_client
+                            .satellite(id)
+                            .and_then(|satellite| {
+                                data_tx
+                                    .send(Event::CommandResponse(Data::Satellite(satellite)))
+                                    .unwrap_or_else(|e| {
+                                        error!("Failed to send Data::Satellite response: {}", e)
+                                    });
+                                Ok(())
+                            })
+                            .unwrap_or_else(|e| error!("Failed to get satellite: {}", e));
                     }
                 }
             }

--- a/monitor/src/settings.rs
+++ b/monitor/src/settings.rs
@@ -37,6 +37,7 @@ pub struct UiConfig {
 #[derive(Debug, Deserialize)]
 pub struct Settings {
     pub api_endpoint: String,
+    pub db_api_endpoint: String,
     pub job_update_interval: u64,
     pub log_level: Option<u64>,
     pub ui: UiConfig,
@@ -51,6 +52,7 @@ impl Settings {
     pub fn new() -> Result<Self, ConfigError> {
         let mut settings = Config::new();
         settings.set_default("api_endpoint", "https://network.satnogs.org/api/")?;
+        settings.set_default("db_api_endpoint", "https://db.satnogs.org/api/")?;
         settings.set_default("job_update_interval", 600)?;
         settings.set_default("log_level", 0)?;
         settings.set_default("ui.db_min", -100.0)?;

--- a/monitor/src/ui.rs
+++ b/monitor/src/ui.rs
@@ -3,6 +3,7 @@ use anyhow::Context as _;
 use chrono::prelude::*;
 use circular_queue::CircularQueue;
 use log::{debug, trace};
+use lru::LruCache;
 use satnogs_network_client::{Client, StationStatus};
 use signal_hook::consts::signal::SIGWINCH;
 use signal_hook::iterator::Signals;
@@ -21,8 +22,10 @@ use tui::widgets::{Axis, Chart, Dataset, Marker};
 
 use std::f64::consts;
 use std::io;
+use std::num::NonZeroUsize;
 use std::sync::mpsc::{sync_channel, Receiver, RecvTimeoutError, SyncSender};
 use std::thread;
+use std::time::Instant;
 
 use crate::event::Event;
 use crate::job::Job;
@@ -57,6 +60,7 @@ pub struct Ui {
     waterfall_data: Vec<(i64, Vec<f32>)>,
     waterfall_frequencies: Vec<f32>,
     waterfall_obs_id: u64,
+    satellite_name_cache: LruCache<u64, (Instant, Option<String>)>,
 }
 
 impl Ui {
@@ -109,7 +113,11 @@ impl Ui {
             events: reciever,
             last_job_update: std::time::Instant::now(),
             logs: CircularQueue::with_capacity(100),
-            network: satnogs::Connection::new(sender.clone(), settings.api_endpoint.clone()),
+            network: satnogs::Connection::new(
+                sender.clone(),
+                settings.api_endpoint.clone(),
+                settings.db_api_endpoint.clone(),
+            ),
             sender,
             settings,
             show_logs: false,
@@ -121,6 +129,7 @@ impl Ui {
             waterfall_obs_id: 0,
             waterfall_frequencies: vec![],
             waterfall_data: vec![],
+            satellite_name_cache: LruCache::new(NonZeroUsize::new(10).unwrap()),
         };
 
         Ok(ui)
@@ -168,6 +177,32 @@ impl Ui {
 
         let station = self.state.get_active_station();
 
+        let vessel_name = if let Some(job) = station.jobs.iter().next() {
+            if let Some((time, result)) = self.satellite_name_cache.get(&job.vessel.id) {
+                if let Some(vessel_name) = result {
+                    vessel_name
+                } else {
+                    if time.elapsed().as_secs() >= 10 {
+                        self.network
+                            .send(satnogs::Command::GetSatellite(job.vessel.id.to_string()))
+                            .unwrap();
+                        self.satellite_name_cache
+                            .push(job.vessel.id, (Instant::now(), None));
+                    }
+                    job.vessel_name()
+                }
+            } else {
+                self.network
+                    .send(satnogs::Command::GetSatellite(job.vessel.id.to_string()))
+                    .unwrap();
+                self.satellite_name_cache
+                    .push(job.vessel.id, (Instant::now(), None));
+                job.vessel_name()
+            }
+        } else {
+            "None"
+        };
+
         let logs = &self.logs;
         let show_logs = self.show_logs;
         let ground_tracks = self.settings.ui.ground_track_num as usize;
@@ -192,7 +227,7 @@ impl Ui {
                     .render(&mut f, rows[0]);
 
                 let mut rect = render_station_view(&mut f, body[0], &station);
-                rect = render_next_job_view(&mut f, rect, &station);
+                rect = render_next_job_view(&mut f, rect, &station, &vessel_name);
                 if let Some(job) = station.jobs.iter().next() {
                     rect = render_polar_plot(&mut f, rect, &job, state);
                 }
@@ -284,7 +319,14 @@ impl Ui {
                     };
                 }
 
-                render_map_view(&mut f, rect, &station, ground_tracks, sat_footprint);
+                render_map_view(
+                    &mut f,
+                    rect,
+                    &station,
+                    ground_tracks,
+                    sat_footprint,
+                    &vessel_name,
+                );
 
                 if show_logs {
                     render_log_view(&mut f, log_area, logs);
@@ -330,6 +372,12 @@ impl Ui {
                     self.state.update_jobs(station_id, jobs);
                     self.state
                         .update_vessel_position(self.settings.ui.ground_track_num);
+                }
+                satnogs::Data::Satellite(satellite) => {
+                    self.satellite_name_cache.push(
+                        satellite.norad_cat_id,
+                        (Instant::now(), Some(satellite.name)),
+                    );
                 }
             },
             Event::Resize => debug!("Terminal size changed"),
@@ -535,6 +583,7 @@ fn render_map_view<T: Backend>(
     station: &Station,
     ground_tracks: usize,
     footprint: bool,
+    vessel_name: &str,
 ) {
     Canvas::default()
         .paint(|ctx| {
@@ -549,7 +598,7 @@ fn render_map_view<T: Backend>(
                 ctx.print(
                     job.sat().lon_deg,
                     job.sat().lat_deg,
-                    format!("■─{}", job.vessel_name()),
+                    format!("■─{}", vessel_name),
                     Color::LightRed,
                 );
                 ctx.layer();
@@ -784,7 +833,12 @@ fn render_station_view<T: Backend>(t: &mut Frame<T>, rect: Rect, station: &Stati
     area[1]
 }
 
-fn render_next_job_view<T: Backend>(t: &mut Frame<T>, rect: Rect, station: &Station) -> Rect {
+fn render_next_job_view<T: Backend>(
+    t: &mut Frame<T>,
+    rect: Rect,
+    station: &Station,
+    vessel_name: &str,
+) -> Rect {
     let mut jobs_rev = station.jobs.iter();
     let mut job_info = vec![];
 
@@ -817,7 +871,7 @@ fn render_next_job_view<T: Backend>(t: &mut Frame<T>, rect: Rect, station: &Stat
             ),
             Text::styled("Vessel       ", Style::default().fg(Color::Cyan)),
             Text::styled(
-                format!("{:>19}\n", job.vessel_name()),
+                format!("{:>19}\n", vessel_name),
                 Style::default().fg(COL_WHITE),
             ),
             Text::styled("Start        ", Style::default().fg(Color::Cyan)),

--- a/satnogs-db-client/Cargo.toml
+++ b/satnogs-db-client/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "satnogs-db-client"
+edition = "2018"
+
+[dependencies]
+chrono = { version = "0.4.19", features = ["serde"] }
+restson = { version = "1.3.0", default-features = false, features = ["blocking", "lib-serde-json", "rustls"] }
+serde = "1.0.138"

--- a/satnogs-db-client/src/client.rs
+++ b/satnogs-db-client/src/client.rs
@@ -1,0 +1,20 @@
+use restson::{blocking, Error, Response, RestClient};
+
+use crate::Satellite;
+
+pub struct Client {
+    client: blocking::RestClient,
+}
+
+impl Client {
+    pub fn new(url: &str) -> Result<Self, Error> {
+        let client = RestClient::new_blocking(url)?;
+        Ok(Client { client })
+    }
+
+    pub fn satellite(&mut self, id: String) -> Result<Satellite, Error> {
+        self.client
+            .get(id)
+            .and_then(|resp: Response<Satellite>| Ok(resp.into_inner()))
+    }
+}

--- a/satnogs-db-client/src/lib.rs
+++ b/satnogs-db-client/src/lib.rs
@@ -1,0 +1,5 @@
+mod client;
+mod satellites;
+
+pub use crate::client::Client;
+pub use crate::satellites::Satellite;

--- a/satnogs-db-client/src/satellites.rs
+++ b/satnogs-db-client/src/satellites.rs
@@ -1,0 +1,30 @@
+use chrono::{DateTime, Utc};
+use restson::{Error, RestPath};
+use serde::Deserialize;
+
+#[derive(Deserialize, Debug)]
+pub struct Satellite {
+    pub sat_id: String,
+    pub norad_cat_id: u64,
+    pub norad_follow_id: Option<u64>,
+    pub name: String,
+    pub names: String,
+    pub image: String,
+    pub status: String,
+    pub decayed: Option<DateTime<Utc>>,
+    pub launched: DateTime<Utc>,
+    pub deployed: Option<DateTime<Utc>>,
+    pub website: String,
+    pub operator: String,
+    pub countries: String,
+    pub updated: DateTime<Utc>,
+    pub citation: String,
+    pub is_frequency_violator: bool,
+    pub associated_satellites: Vec<String>,
+}
+
+impl RestPath<String> for Satellite {
+    fn get_path(id: String) -> Result<String, Error> {
+        Ok(format!("/api/satellites/{}/", id))
+    }
+}


### PR DESCRIPTION
Instead of displaying the name from the tle provided by the network api, fetch the actual name from satnogs db api.
The last 100 satellite names will be cached, if a request fails it will retry in 10 minutes and display the tle name instead.
This is not implemented for the future jobs display yet.